### PR TITLE
Allow the use of builtins, keywords and numbers as choices 

### DIFF
--- a/choices/__init__.py
+++ b/choices/__init__.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-
+import keyword
 
 #TODO: can we just sub-class tuple and be a tuple of tuples with attributes?
 class Choices(object):
@@ -16,6 +16,19 @@ class Choices(object):
 
     def __getattr__(self, name):
         try:
+            if name.startswith("_") and name[1:] in self._choices:
+                without_underscore = name[1:]
+                special = False
+                try:
+                    int(without_underscore)
+                    special = True
+                except (TypeError, ValueError):
+                    special = without_underscore in keyword.kwlist or \
+                              without_underscore in __builtins__.keys()
+
+                if special:
+                    return without_underscore
+
             self._choices[name] #check it exists
             return name
         except KeyError:

--- a/choices/__init__.py
+++ b/choices/__init__.py
@@ -33,6 +33,13 @@ class Choices(object):
                 if special:
                     return without_underscore
 
+            if name not in self._choices:
+                # Another special case, if we have spaces or hyphens, provide
+                # access using underscores in place
+                for k in self._choices:
+                    if k.replace("-", "_").replace(" ", "_") == name:
+                        return k
+
             self._choices[name] #check it exists
             return name
         except KeyError:

--- a/choices/__init__.py
+++ b/choices/__init__.py
@@ -21,7 +21,7 @@ class Choices(object):
 
                 # Check if the name is a Python keyword, builtin or an integer
                 # if it is, we allow access with a leading underscore, but if not
-                # we fall through an throw the normal key error
+                # we fall through and throw the normal KeyError
                 special = False
                 try:
                     int(without_underscore)

--- a/choices/__init__.py
+++ b/choices/__init__.py
@@ -14,6 +14,8 @@ class Choices(object):
         assert 'choices' not in self._choices.keys()
         assert 'constants' not in self._choices.keys()
 
+        # Sanity check to make sure there are no conflicting constants
+        # once spaces and hyphens have been removed
         seen_lookups = set()
         for constant, _ in choices:
             sanitized = constant.replace("-", "_").replace(" ", "_")

--- a/choices/__init__.py
+++ b/choices/__init__.py
@@ -43,7 +43,7 @@ class Choices(object):
             self._choices[name] #check it exists
             return name
         except KeyError:
-            return super(Choices, self).__getattr__(name)
+            raise AttributeError("Choices object has no such attribute {}".format(name))
 
     def __setattr__(self, name, value):
         """ Prevent values being changed. """

--- a/choices/__init__.py
+++ b/choices/__init__.py
@@ -35,7 +35,7 @@ class Choices(object):
 
             if name not in self._choices:
                 # Another special case, if we have spaces or hyphens, provide
-                # access using underscores in place
+                # access using underscores in their place
                 for k in self._choices:
                     if k.replace("-", "_").replace(" ", "_") == name:
                         return k

--- a/choices/__init__.py
+++ b/choices/__init__.py
@@ -18,6 +18,10 @@ class Choices(object):
         try:
             if name.startswith("_") and name[1:] in self._choices:
                 without_underscore = name[1:]
+
+                # Check if the name is a Python keyword, builtin or an integer
+                # if it is, we allow access with a leading underscore, but if not
+                # we fall through an throw the normal key error
                 special = False
                 try:
                     int(without_underscore)

--- a/choices/__init__.py
+++ b/choices/__init__.py
@@ -14,6 +14,14 @@ class Choices(object):
         assert 'choices' not in self._choices.keys()
         assert 'constants' not in self._choices.keys()
 
+        seen_lookups = set()
+        for constant, _ in choices:
+            sanitized = constant.replace("-", "_").replace(" ", "_")
+            if sanitized in seen_lookups:
+                raise ValueError("Attempted to add conflicting option {}".format(constant))
+            else:
+                seen_lookups.add(sanitized)
+
     def __getattr__(self, name):
         try:
             if name.startswith("_") and name[1:] in self._choices:

--- a/choices/tests.py
+++ b/choices/tests.py
@@ -27,6 +27,8 @@ class ChoicesTestCase(unittest.TestCase):
         self.assertEqual(special._id, "id")
         self.assertEqual(special._1, "1")
         self.assertEqual(special._in, "in")
+
+        # Underscore access should only work for keywords and numbers
         self.assertRaises(AttributeError, getattr, special, "_xx")
 
     def test_choices_property(self):

--- a/choices/tests.py
+++ b/choices/tests.py
@@ -16,6 +16,19 @@ class ChoicesTestCase(unittest.TestCase):
         self.assertEqual(colours.white, 'white')
         self.assertEqual(colours.black, 'black')
 
+    def test_python_keywords_and_numbers(self):
+        special = Choices([
+            ("id", "ID"),
+            ("1", "One"),
+            ("in", "IN"),
+            ("xx", "XX")
+        ])
+
+        self.assertEqual(special._id, "id")
+        self.assertEqual(special._1, "1")
+        self.assertEqual(special._in, "in")
+        self.assertRaises(AttributeError, getattr, special, "_xx")
+
     def test_choices_property(self):
         self.assertEqual(
             tuple(colours.choices),

--- a/choices/tests.py
+++ b/choices/tests.py
@@ -16,6 +16,15 @@ class ChoicesTestCase(unittest.TestCase):
         self.assertEqual(colours.white, 'white')
         self.assertEqual(colours.black, 'black')
 
+    def test_hyphens_and_spaces(self):
+        special = Choices([
+            ("en-GB", "ID"),
+            ("my thing", "One"),
+        ])
+
+        self.assertEqual(special.en_GB, "en-GB")
+        self.assertEqual(special.my_thing, "my thing")
+
     def test_python_keywords_and_numbers(self):
         special = Choices([
             ("id", "ID"),

--- a/choices/tests.py
+++ b/choices/tests.py
@@ -25,6 +25,9 @@ class ChoicesTestCase(unittest.TestCase):
         self.assertEqual(special.en_GB, "en-GB")
         self.assertEqual(special.my_thing, "my thing")
 
+        # Check that we don't allow conflicting choices
+        self.assertRaises(ValueError, Choices, [("en-GB", "1"), ("en_GB", "2")])
+
     def test_python_keywords_and_numbers(self):
         special = Choices([
             ("id", "ID"),


### PR DESCRIPTION
Fixes the following issues:

1. Python builtins, keywords and integers can now be used as constants, and can be accessed directly by prefixing with an underscore
2. Constants with hyphens can now be accessed by replacing them with underscores (e.g. en_GB instead of en-GB)
3. AttributeError wasn't being correctly raised (was instead complaining that the `super()` object had no `__getattr__` )

This allows working with these edge cases without drastically changing the existing API.